### PR TITLE
Fix typo in postgres_password prompt

### DIFF
--- a/kontena.yml
+++ b/kontena.yml
@@ -30,7 +30,7 @@ variables:
     from:
       vault: ${STACK}-postgres-password
       env: PG_PASSWORD
-      prompt: Postgres password? (or emtpy to generate random)
+      prompt: Postgres password? (or empty to generate random)
       random_string: 32
     to:
       vault: ${STACK}-postgres-password


### PR DESCRIPTION
Just a minor typo fix.